### PR TITLE
Show prettier errors as phantoms within code if supported and enabled

### DIFF
--- a/JsPrettier.sublime-settings
+++ b/JsPrettier.sublime-settings
@@ -183,6 +183,20 @@
 	"max_file_size_limit": -1,
 
 	// ----------------------------------------------------------------------
+	// Show Error Output from Prettier as Phantoms
+	// ----------------------------------------------------------------------
+	//
+	// @param {bool} "show_error_phantoms"
+	// @default false
+	//
+	// When enabled (true), potential errors from Prettier (e.g., syntax
+	// errors in your code) will be shown directly within the code at the
+	// location where they occurred.
+	// This is only supported in Sublime Text versions > 3118.
+	// ----------------------------------------------------------------------
+	"show_error_phantoms": false,
+
+	// ----------------------------------------------------------------------
 	// Prettier Options
 	// ----------------------------------------------------------------------
 	//


### PR DESCRIPTION
I noticed that Prettier is quite fast at formatting and also at checking syntax (since it fails when the syntax is incorrect). Since it's way faster than linting for me, I thought it would be useful to get the error feedback a bit more prominent than in the status bar.

New sublime versions support "phantoms" which I used to implement this feature:

![image](https://user-images.githubusercontent.com/2486553/28998380-d94db73a-7a29-11e7-884f-5e8e1a648f59.png)

If prettier is run and fails the output will be parsed and shown as a phantom. If the buffer is changed, the phantom will disappear.
I made it optional and turned it off by default. However, I'd advocate to enable it by default :)