### PR TITLE
Don't halt execution on warnings

### DIFF
--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -369,9 +369,11 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
                 env=self.proc_env,
                 shell=self.is_windows())
             stdout, stderr = proc.communicate(input=source.encode('utf-8'))
-            if stderr or proc.returncode != 0:
+            if proc.returncode != 0:
                 self.error_message = self.format_error_message(stderr.decode('utf-8'), str(proc.returncode))
                 return None
+            if stderr:
+                print(self.format_error_message(stderr.decode('utf-8'), str(proc.returncode)))
             return stdout.decode('utf-8')
         except OSError as ex:
             sublime.error_message('{0} - {1}'.format(PLUGIN_NAME, ex))

--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -370,7 +370,7 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
                 shell=self.is_windows())
             stdout, stderr = proc.communicate(input=source.encode('utf-8'))
             if stderr or proc.returncode != 0:
-                self.format_error_message(stderr.decode('utf-8'), str(proc.returncode))
+                self.error_message = self.format_error_message(stderr.decode('utf-8'), str(proc.returncode))
                 return None
             return stdout.decode('utf-8')
         except OSError as ex:
@@ -579,9 +579,9 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
               '{1}'.format(PLUGIN_NAME, self.error_message))
 
     def format_error_message(self, error_message, error_code):
-        self.error_message = 'Prettier reported the following ' \
-                             'error:\n\n{0}\n' \
-                             'Process finished with exit code {1}\n'\
+        return 'Prettier reported the following ' \
+               'error:\n\n{0}\n' \
+               'Process finished with exit code {1}\n'\
             .format(error_message, '{0}'
                     .format(error_code))
 


### PR DESCRIPTION
Closes #72

Warnings are sent to stderr, but their existence shouldn't halt execution. They should be logged, and execution should only be halted if prettier's exit code is non-zero.