### PR TITLE
Added support for VUE js

### DIFF
--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -88,7 +88,8 @@ AUTO_FORMAT_FILE_EXTENSIONS = [
     'css',
     'scss',
     'less',
-    'md'
+    'md',
+    'vue'
 ]
 
 
@@ -568,6 +569,11 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
                     prettier_options.append('markdown')
                     continue
 
+                if self.is_vue(view):
+                    prettier_options.append(cli_option_name)
+                    prettier_options.append('vue')
+                    continue
+
             if not prettier_config_exists and not has_custom_config_defined:
                 # add the cli args or the respective defaults:
                 if option_value is None or str(option_value) == '':
@@ -737,6 +743,16 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
             return False
         scopename = view.scope_name(0)
         if scopename.startswith('text.html.markdown') or filename.endswith('.md'):
+            return True
+        return False
+
+    @staticmethod
+    def is_vue(view):
+        filename = view.file_name()
+        if not filename:
+            return False
+        scopename = view.scope_name(0)
+        if scopename.startswith('text.html.vue') or filename.endswith('.vue'):
             return True
         return False
 


### PR DESCRIPTION
Prettier now natively formats single file vue js but that feature [requires prettier v1.10+](https://prettier.io/blog/2018/01/10/1.10.0.html#support-for-vue-single-file-components-3563-by-vjeux)

In this PR
=======
 * [x] Auto format `.vue` files
 * [x] Auto detect/set `vue` parser for `.vue` files and scope `text.html.vue`