### PR TITLE
Don't force --tab-width and --use-tabs option when user specifies a config

### DIFF
--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -475,13 +475,14 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
                 prettier_options.append(cli_option_name)
                 prettier_options.append(option_value)
 
-        # set the `tabWidth` option based on the current view:
-        prettier_options.append('--tab-width')
-        prettier_options.append(str(self.tab_size))
+        if not prettier_config_exists and not has_custom_config_defined:
+                # set the `tabWidth` option based on the current view:
+                prettier_options.append('--tab-width')
+                prettier_options.append(str(self.tab_size))
 
-        # set the `useTabs` option based on the current view:
-        prettier_options.append('--use-tabs')
-        prettier_options.append(str(self.use_tabs).lower())
+                # set the `useTabs` option based on the current view:
+                prettier_options.append('--use-tabs')
+                prettier_options.append(str(self.use_tabs).lower())
 
         # add the current file name to `--stdin-filepath`, only when
         # the current file being edited is NOT html, and in order


### PR DESCRIPTION
SublimeJsPrettier uses the `--tab-width` and `--use-tabs` options to `prettier` with the buffer's tab size and tab width from Sublime. For most users, this will be the auto-detected tab width and tab size, since auto-detection is the default. However sometimes Sublime guesses wrong, despite the file being formatted by `prettier` (this happens to me on this file: https://github.com/drew-gross/mpl/blob/master/api.ts).

When this happens the tab width specified in your prettier configuration is overridden by the incorrectly auto-detected tab width detected by Sublime, which causes the result of formatting using SublimeJsPrettier to not match the result of formatting using `prettier` on the command line.

This PR fixes that issue by only passing `--tab-width` and `--use-tabs` on the command line if the user didn't specify a config.