### PR TITLE
Fix typo in status message

### DIFF
--- a/jsprettier/sthelper.py
+++ b/jsprettier/sthelper.py
@@ -15,7 +15,7 @@ import sublime
 
 
 def st_status_message(msg):
-    sublime.set_timeout(lambda: sublime.status_message('{0}: {1}'.format('JsPretter', msg)), 0)
+    sublime.set_timeout(lambda: sublime.status_message('{0}: {1}'.format('JsPrettier', msg)), 0)
 
 
 def get_setting(view, key, default_value=None):


### PR DESCRIPTION
I just loaded JsPrettier today and it is great! When I ran JsPrettier via keybinding as in the doc, I saw my ST bottom statusbar read:

`JsPretter: File formatted.`

I thought I could fix the typo to say thanks for making such a great package! Thank you