### PR TITLE
Use `--cursor-offset` to request the new cursor position

### DIFF
--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -389,12 +389,14 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
                 return None
 
             if stderr:
-                # allow warnings to pass-through
                 stderr_output = stderr.decode('utf-8')
                 if provide_cursor:
                     stderr_lines = stderr_output.splitlines()
                     stderr_output, new_cursor = '\n'.join(stderr_lines[:-1]), stderr_lines[-1]
-                print(format_error_message(stderr_output, str(proc.returncode)))
+
+                # allow warnings to pass-through
+                if stderr_output:
+                    print(format_error_message(stderr_output, str(proc.returncode)))
 
             if provide_cursor:
                 return stdout.decode('utf-8'), int(new_cursor)

--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -278,12 +278,14 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
             if is_str_empty_or_whitespace_only(source):
                 return st_status_message('Nothing to format in file.')
 
-            transformed, new_cursor = self.format_code(
+            result = self.format_code(
                 source, node_path, prettier_cli_path, prettier_options, view,
                 provide_cursor=True)
             if self.has_error:
                 self.format_console_error()
                 return self.show_status_bar_error()
+
+            transformed, new_cursor = result
 
             # sanity check to ensure textual content was returned from cmd
             # stdout, not necessarily caught in OSError try/catch

--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -278,7 +278,9 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
             if is_str_empty_or_whitespace_only(source):
                 return st_status_message('Nothing to format in file.')
 
-            transformed = self.format_code(source, node_path, prettier_cli_path, prettier_options, view)
+            transformed, new_cursor = self.format_code(
+                source, node_path, prettier_cli_path, prettier_options, view,
+                provide_cursor=True)
             if self.has_error:
                 self.format_console_error()
                 return self.show_status_bar_error()
@@ -308,6 +310,8 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
                 source_modified = True
 
             if source_modified:
+                view.sel().clear()
+                view.sel().add(sublime.Region(new_cursor))
                 st_status_message('File formatted.')
             else:
                 st_status_message('File already formatted.')
@@ -343,8 +347,12 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
                 view.replace(edit, region, transformed)
                 st_status_message('Selection(s) formatted.')
 
-    def format_code(self, source, node_path, prettier_cli_path, prettier_options, view):
+    def format_code(self, source, node_path, prettier_cli_path, prettier_options, view, provide_cursor=False):
         self._error_message = None
+
+        if provide_cursor:
+            cursor = view.sel()[0].a
+            prettier_options += ['--cursor-offset', str(cursor)]
 
         if is_str_none_or_empty(node_path):
             cmd = [prettier_cli_path] \
@@ -377,9 +385,18 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
                     scroll_view_to(view, error_line, error_col)
 
                 return None
+
             if stderr:
                 # allow warnings to pass-through
-                print(format_error_message(stderr.decode('utf-8'), str(proc.returncode)))
+                stderr_output = stderr.decode('utf-8')
+                if provide_cursor:
+                    stderr_lines = stderr_output.splitlines()
+                    stderr_output, new_cursor = '\n'.join(stderr_lines[:-1]), stderr_lines[-1]
+                print(format_error_message(stderr_output, str(proc.returncode)))
+
+            if provide_cursor:
+                return stdout.decode('utf-8'), int(new_cursor)
+
             return stdout.decode('utf-8')
         except OSError as ex:
             sublime.error_message('{0} - {1}'.format(PLUGIN_NAME, ex))


### PR DESCRIPTION
Via `--cursor-offset` we inform Prettier about the current cursor position, and as a thank you get the new cursor position back on stderr (after eventual warnings, t.i. at the end of stderr).

We use that to move the cursor after transforming the buffer.