### PR TITLE
Do not monkey-patch sublime.Region

### DIFF
--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -15,10 +15,6 @@ from subprocess import Popen
 import sublime
 import sublime_plugin
 
-#
-# Monkey patch `sublime.Region` so it can be iterable:
-sublime.Region.totuple = lambda self: (self.a, self.b)
-sublime.Region.__iter__ = lambda self: self.totuple().__iter__()
 
 PLUGIN_PATH = os.path.join(sublime.packages_path(), os.path.dirname(os.path.realpath(__file__)))
 

--- a/jsprettier/sthelper.py
+++ b/jsprettier/sthelper.py
@@ -129,8 +129,7 @@ def scroll_view_to(view, row_no, col_no):
 
 def has_selection(view):
     for sel in view.sel():
-        start, end = sel
-        if start != end:
+        if not sel.empty():
             return True
     return False
 


### PR DESCRIPTION
In a shared runtime environment it is not 'polite' behavior to monkey-patch something and everyone else has to deal with it. 

(I actually had one bug in SL because of that.)

I didn't saw any other occurrences of sel unpacking, but maybe you remember why you needed/wanted that patch in the first place.