### PR TITLE
Set re.M flag when searching for syntax errors

### DIFF
--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -5,10 +5,10 @@ from __future__ import print_function
 
 import fnmatch
 import os
+import re
 import sys
 
 from re import match
-from re import search
 from subprocess import PIPE
 from subprocess import Popen
 
@@ -24,6 +24,10 @@ PLUGIN_PATH = os.path.join(sublime.packages_path(), os.path.dirname(os.path.real
 
 IS_ST3 = int(sublime.version()) >= 3000
 IS_PY2 = sys.version_info[0] == 2
+
+SYNTAX_ERROR_RE = re.compile(
+    r'^.+?:\s(?:(?P<error>SyntaxError)):\s(?P<message>.+) \((?P<line>\d+):(?P<col>\d+)\)',
+    re.M)
 
 if IS_PY2:
     # st with python 2x
@@ -513,8 +517,7 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
         message = ''
         line = -1
         col = -1
-        match_groups = search(
-            r'^.+?:\s(?:(?P<error>SyntaxError)):\s(?P<message>.+) \((?P<line>\d+):(?P<col>\d+)\)', error_output)
+        match_groups = SYNTAX_ERROR_RE.search(error_output)
         if match_groups:
             error = match_groups.group('error')
             message = match_groups.group('message')


### PR DESCRIPTION
If you have additional output on stderr, the actual SyntaxError hint doesn't have to be on the first line. E.g. you might have

```
[warn] Ignored unknown option: --arrow-parens
[error] stdin: SyntaxError: Unexpected token (22:33)
[error]   20 |
<SNIP>
```

We just set `re.M` and are hopefully good to go.