### PR TITLE
Fixes crash

### DIFF
--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -121,7 +121,7 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
 
     @property
     def tab_size(self):
-        return int(self.view.settings().get('tab_size', 2))
+        return int(get_setting(self.view, 'tab_size', 2))
 
     @property
     def use_tabs(self):


### PR DESCRIPTION
Earlier implementation raises error: int() argument must be a string or a number, not 'NoneType'