### PR TITLE
Add setting to disallow using Sublime's spacing preferences.

### DIFF
--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -129,6 +129,14 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
         return not translate_tabs_to_spaces
 
     @property
+    def use_view_use_tabs(self):
+        return get_setting(self.view, 'use_view_use_tabs', True)
+
+    @property
+    def use_view_tab_size(self):
+        return get_setting(self.view, 'use_view_tab_size', True)
+
+    @property
     def allow_inline_formatting(self):
         return get_setting(self.view, 'allow_inline_formatting', False)
 
@@ -523,12 +531,14 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
                 prettier_options.append(option_value)
 
         # set the `tabWidth` option based on the current view:
-        prettier_options.append('--tab-width')
-        prettier_options.append(str(self.tab_size))
+        if self.use_view_use_tabs:
+            prettier_options.append('--tab-width')
+            prettier_options.append(str(self.tab_size))
 
         # set the `useTabs` option based on the current view:
-        prettier_options.append('--use-tabs')
-        prettier_options.append(str(self.use_tabs).lower())
+        if self.use_view_tab_size:
+            prettier_options.append('--use-tabs')
+            prettier_options.append(str(self.use_tabs).lower())
 
         if prettier_ignore_filepath is not None:
             prettier_options.append('--ignore-path')

--- a/JsPrettier.sublime-settings
+++ b/JsPrettier.sublime-settings
@@ -155,6 +155,32 @@
 	"custom_file_extensions": [],
 
 	// ----------------------------------------------------------------------
+	// Use Sublime View's Tab Setting
+	// ----------------------------------------------------------------------
+	//
+	// @param {bool} "use_view_use_tabs"
+	// @default true
+	//
+	// Uses Sublime Text's view indentation preference (located on the bottom
+	// right menu as "Indent Using Spaces"). This defaults to tabs in Sublime
+	// Text global preferences.
+	// ----------------------------------------------------------------------
+	"use_view_use_tabs": true,
+
+	// ----------------------------------------------------------------------
+	// Use Sublime View's Tab Setting
+	// ----------------------------------------------------------------------
+	//
+	// @param {bool} "use_view_tab_size"
+	// @default true
+	//
+	// Uses Sublime Text's view tab size preference (located on the bottom
+	// right menu as "Tab Width: x"). This defaults to 4 in Sublime
+	// Text global preferences.
+	// ----------------------------------------------------------------------
+	"use_view_tab_size": true,
+
+	// ----------------------------------------------------------------------
 	// Maximum File Size Limit
 	// ----------------------------------------------------------------------
 	//


### PR DESCRIPTION
I find Sublime never properly detects the spacing options of my files (I think it's especially apparent in new files) and width for my projects so I would rather allow JsPrettier to use the `.prettierrc` settings instead of it trying to use Sublime's view preferences.

This PR adds two settings which default to `true` so there's no breaking changes, `use_view_use_tabs`, and `use_view_tab_size`.

https://github.com/jonlabelle/SublimeJsPrettier/issues/125