### PR TITLE
Change HTML parser to html from parse5

### DIFF
--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -514,7 +514,7 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
 
                 if self.is_html(view):
                     prettier_options.append(cli_option_name)
-                    prettier_options.append('parse5')
+                    prettier_options.append('html')
                     continue
 
             if not prettier_config_exists and not has_custom_config_defined:


### PR DESCRIPTION
Prettier version 1.15 added HTML support and renamed parse5 to html.

[Pretttier HTML Todos](https://github.com/prettier/prettier/issues/5098)
[Prettier HTML Support PR](https://github.com/prettier/prettier/pull/5259)
[Prettier release 1.15 notes](https://prettier.io/blog/2018/11/07/1.15.0.html)

