### PR TITLE
Improvements regarding package.json and html

### DIFF
--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -483,6 +483,11 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
                     prettier_options.append('typescript')
                     continue
 
+                if self.is_package_json(view):
+                    prettier_options.append(cli_option_name)
+                    prettier_options.append('json-stringify')
+                    continue
+
                 if self.is_json(view):
                     prettier_options.append(cli_option_name)
                     prettier_options.append('json')
@@ -620,6 +625,16 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
             return False
         scopename = view.scope_name(0)
         if scopename.startswith('source.json') or filename.endswith('.json'):
+            return True
+        return False
+
+    @staticmethod
+    def is_package_json(view):
+        filename = os.path.basename(view.file_name())
+        if not filename:
+            return False
+        scopename = view.scope_name(0)
+        if scopename.startswith('source.json') and (filename == 'package.json'):
             return True
         return False
 

--- a/jsprettier/const.py
+++ b/jsprettier/const.py
@@ -95,5 +95,7 @@ AUTO_FORMAT_FILE_EXTENSIONS = [
     'vue',
     'yml',
     'mjs',
-    'mdx'
+    'mdx',
+    'htm',
+    'html'
 ]


### PR DESCRIPTION
This official [prettier-vscode](https://github.com/prettier/prettier-vscode) treats `package.json` differently and sets its `parser` to `json-stringify`. This PR is intended to match that behavior. Additionally, I've added html to the auto-format extensions.