### PR TITLE
Fix resolving file extension from file path for dot-files

### DIFF
--- a/jsprettier/sthelper.py
+++ b/jsprettier/sthelper.py
@@ -88,7 +88,9 @@ def is_file_auto_formattable(view):
     filename = view.file_name()
     if not filename:
         return False
-    file_ext = os.path.splitext(filename)[1][1:]
+    file_ext = filename.rpartition('.')[-1]
+    if file_ext == filename:
+        return False
     if file_ext in AUTO_FORMAT_FILE_EXTENSIONS:
         return True
     if file_ext in set(get_setting(view, 'custom_file_extensions', [])):


### PR DESCRIPTION
This commit fixes the bug with not prettifying dot-files (`.eslintrc`, `.prettirerc`, `.firebaserc`) when they are added in "custom_file_extensions” array in plugin settings.

The problem was that this code returns empty string and not “eslintrc” for `.eslintrc` file

```
os.path.splitext(“.eslintrc”)[1][1:]
```

I tested this fix for regular files, dot-files (`.eslintrc`, `.prettirerc`, `.firebaserc`), files with multiple dots in their name (`file.tar.gz`), files without extension and everything works fine in all cases.