### PR TITLE
README: specify minimum Prettier version

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Operating Systems.
 - [Sublime Text] - Text editor for code
 - [node.js] - JavaScript runtime
 - [yarn] or [npm] - Package manager for JavaScript
-- [Prettier] - Opinionated JavaScript formatter
+- [Prettier] - Opinionated JavaScript formatter - v1.16 or above
 
 ### Install Prettier
 


### PR DESCRIPTION
A recent commit (f5fd07b25aad5793540094dff820d085254b1a72) means that SublimeJsPrettier now only supports versions of Prettier v1.16 and above.

This PR adds the minimum version of Prettier required to the README. This should help others who run into the 'Error: Couldn't resolve parser "babel"' issue described in #157.
