### PR TITLE
Restore viewport position to prevent screen jumping(horizontal and vertical)

### DIFF
--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -304,6 +304,8 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
 
             source_modified = False
             transformed = trim_trailing_ws_and_lines(transformed)
+            previous_position = self.view.viewport_position()
+
             if transformed:
                 if transformed == trim_trailing_ws_and_lines(source):
                     if self.ensure_newline_at_eof(view, edit) is True:
@@ -318,6 +320,9 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
                 view.replace(edit, region, transformed)
                 self.ensure_newline_at_eof(view, edit)
                 source_modified = True
+
+            self.view.set_viewport_position((0, 0), False)
+            self.view.set_viewport_position(previous_position, False)
 
             if source_modified:
                 view.sel().clear()


### PR DESCRIPTION
Hey, thanks for this plugin.  I've been manually setting this for a couple years and make this change every time I reformat/reinstall the OS on my computer(I never bothered to fork it).  I got tired of making the change so I thought I would send in a PR.

It prevents the viewport from scrolling/jumping after saving.  I got this from another plugin(I think JS beautify) but it's been so long I can't remember.

Before:

![jump](https://user-images.githubusercontent.com/1056587/55670894-9a8f6a80-5857-11e9-8abf-7c001729f168.gif)

After:

![no-jump](https://user-images.githubusercontent.com/1056587/55670898-9d8a5b00-5857-11e9-904e-7f3f60c5d209.gif)
