### PR TITLE
Do not deploy screenshots to endusers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,5 @@
 appveyor.yml  text  eol=crlf
 
 *.gif         binary
+
+screenshots/         export-ignore


### PR DESCRIPTION
This PR reduces the package size from `1.08 MB` to `164 KB` by excluding `screenshots/` from being deployed.

In case people wondering how this works, see https://github.com/math2001/FileManager/pull/41#issuecomment-554541489.