### PR TITLE
fixed format not running for newlines at end of file

### DIFF
--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -299,13 +299,14 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
                 return self.show_status_bar_error()
 
             source_modified = False
+            prettified_text_with_ws_and_lines = prettified_text
             prettified_text = trim_trailing_ws_and_lines(prettified_text)
 
             # Store viewport position to prevent screen jumping (#171):
             previous_position = view.viewport_position()
 
             if prettified_text:
-                if prettified_text == trim_trailing_ws_and_lines(source_text):
+                if prettified_text_with_ws_and_lines == source_text:
                     if self.ensure_newline_at_eof(view, edit) is True:
                         # no formatting changes applied, however, a line
                         # break was needed/inserted at the end of the file:


### PR DESCRIPTION
I _think_ this is the more correct way to handle formats. Previously, if your file was properly formatted except for newlines/whitespace at the end of the file, JsPrettier would not actually apply the format despite it not actually being fully formatted by the underlying `prettier`. This causes formatting inconsistencies and can result in CI checks to fail if you're enforcing prettier formats across your codebase.

Doing a direct comparison of `prettified_text` and `source_text` without being trimmed I think makes it behave the way that is desired, but please advise if not.

Fixes #138 