### PR TITLE
Support new singleAttributePerLine option

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -84,6 +84,7 @@ To view the generated prettier command line arguments you need to enable JsPrett
         --embedded-language-formatting auto \
         --use-tabs false                    \
         --editorconfig true                 \
+        --single-attribute-per-line false   \
         --stdin-filepath messy.js           \
         --loglevel debug
 
@@ -97,7 +98,7 @@ To view the generated prettier command line arguments you need to enable JsPrett
 
 ## Is the same behavior observed when run against Prettier directly?
 
-For example, the following command passes the contents of `messy_formatted_file.js` to Prettier and prints the formatted to stdout:
+For example, the following command passes the contents of `messy.js` to Prettier and prints the formatted to stdout:
 
     /usr/local/bin/prettier                 \
         --no-config                         \
@@ -119,6 +120,7 @@ For example, the following command passes the contents of `messy_formatted_file.
         --embedded-language-formatting auto \
         --use-tabs false                    \
         --editorconfig true                 \
+        --single-attribute-per-line false   \
         --stdin-filepath messy.js           \
         --loglevel debug                    \
         < messy.js
@@ -159,7 +161,8 @@ The entire contents of your ***User*** overridden JsPrettier Settings, excluding
             "quoteProps": "as-needed",
             "vueIndentScriptAndStyle": false,
             "embeddedLanguageFormatting": "auto",
-            "editorconfig": true
+            "editorconfig": true,
+            "singleAttributePerLine": false
         }
     }
 
@@ -206,7 +209,8 @@ The entire contents of your ***User*** overridden JsPretter Project-level Settin
                     "quoteProps": "as-needed",
                     "vueIndentScriptAndStyle": false,
                     "embeddedLanguageFormatting": "auto",
-                    "editorconfig": true
+                    "editorconfig": true,
+                    "singleAttributePerLine": false
                 }
             }
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.60.0
+
+**Release Date:** 2022-03-18
+
+Added setting to support new `singleAttributePerLine` option, which can force
+each attribute to be placed on a single line in HTML, Vue and JSX.
+
+- [Single Line Attribute](https://prettier.io/docs/en/options.html#single-attribute-per-line)
+- [Prettier 2.6: new singleAttributePerLine option and new JavaScript features!](https://prettier.io/blog/2022/03/16/2.6.0.html#enforce-single-attribute-per-line-6644httpsgithubcomprettierprettierpull6644-by-kankjehttpsgithubcomkankje)
+
 ## 1.50.0
 
 **Release Date:** 2021-09-12
@@ -54,7 +64,7 @@ Tab trigger is `pi`.
   being fully formatted by the underlying prettier. This causes formatting
   inconsistencies and can result in CI checks to fail if you're enforcing
   prettier formats across your codebase.
-  
+
   Thanks [rkoval](https://github.com/jonlabelle/SublimeJsPrettier/pull/213)!
 
 ## 1.30.0
@@ -63,7 +73,7 @@ Tab trigger is `pi`.
 
 - Try to resolve Prettier closest to the current view first; and when a
   custom path isn't specified.
-  
+
   Thanks [nfmc](https://github.com/jonlabelle/SublimeJsPrettier/pull/207)!
 
 ## 1.29.0
@@ -95,11 +105,11 @@ Tab trigger is `pi`.
 
 - Added support for new Prettier [Quote Props] option; changes quotes around
   object properties (requires [Prettier v1.17+]).
-  
+
     - Default: `"as-needed"`
     - CLI Override: `--quote-props <as-needed|consistent|preserve>`
     - API Override: `quoteProps:` `"<as-needed|consistent|preserve>"`
-  
+
   **Valid options:**
 
     - `"as-needed"` (default) - Only add quotes around object properties where required.
@@ -119,12 +129,12 @@ Tab trigger is `pi`.
   The issue effectively results in the CPU spiking to a constant 100%...
   indefinitely, or until the node executable/process running Prettier is
   forcefully terminated.
-  
+
   To avoid this problematic behavior, or until the defect is resolved, you can
   disable the plug-in (JsPrettier) from ever passing the cursor offset
   position to Prettier by setting the `disable_prettier_cursor_offset` value
   to `true`.
-  
+
     - See related issues: [#147](https://github.com/jonlabelle/SublimeJsPrettier/issues/147), [#168](https://github.com/jonlabelle/SublimeJsPrettier/issues/168)
     - [Prettier Cursor Offset Documentation](https://prettier.io/docs/en/api.html#prettierformatwithcursorsource-options)
 
@@ -156,7 +166,7 @@ Tab trigger is `pi`.
   and options defined in `additional_cli_args` (e.g. `--config` `<path>`).
 
   Check-out the [default settings] \(comment section) for examples.
-  
+
 ## 1.23.0
 
 **Release Date:** 2019-01-25
@@ -166,7 +176,7 @@ Tab trigger is `pi`.
 
   See the [Prettier v1.16] release notes page for additional information on the
   parser change, including new features and bug fixes.
-  
+
 ## 1.22.0
 
 **Release Date:** 2019-01-21
@@ -188,8 +198,8 @@ Tab trigger is `pi`.
 
 - Added new `auto_format_on_save_requires_prettier_config` setting that will
   enable/disable auto format on save *only* if a Prettier config file is (or isn't) found.
-  
-  The Prettier config file is resolved by first checking if a `--config </path/to/prettier/config>`  
+
+  The Prettier config file is resolved by first checking if a `--config </path/to/prettier/config>`
   is specified in the `additional_cli_args` setting, then by searching the
   location of the file being formatted, and finally navigating up the file tree
   until a config file is (or isn't) found.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,9 +90,9 @@ Tab trigger is `pi`.
   option; determines whether or not to indent the code inside `<script>` and
   `<style>` tags in Vue files (requires [Prettier v1.19+]).
 
-  | Default |              CLI Override              |            API Override           |              Sublime Text             |
-  |---------|----------------------------------------|-----------------------------------|---------------------------------------|
-  | `false` | `--vue-indent-script-and-style <bool>` | `vueIndentScriptAndStyle: <bool>` | [`"vueIndentScriptAndStyle": <bool>`] |
+  | Default |              CLI Override              |            API Override           |
+  |---------|----------------------------------------|-----------------------------------|
+  | `false` | `--vue-indent-script-and-style <bool>` | `vueIndentScriptAndStyle: <bool>` |
 
   **Valid options:**
 
@@ -456,5 +456,4 @@ Tab trigger is `pi`.
 [Quote Props]: https://prettier.io/docs/en/options.html#quote-props
 [Vue files script and style tags indentation]: https://prettier.io/docs/en/options.html#vue-files-script-and-style-tags-indentation
 [Prettier v1.19+]: https://prettier.io/blog/2019/11/09/1.19.0.html
-[`"vueIndentScriptAndStyle": <bool>`]: https://github.com/jonlabelle/SublimeJsPrettier/blob/master/JsPrettier.sublime-settings#L502
 [Prettier v2.1+]: https://prettier.io/blog/2020/08/24/2.1.0.html

--- a/JsPrettier.sublime-settings
+++ b/JsPrettier.sublime-settings
@@ -327,9 +327,9 @@
 		//
 		// Valid options:
 		//
-		// "none" - No trailing commas
-		// "es5"  - Trailing commas where valid in ES5 (objects, arrays, etc)
-		// "all"  - Trailing commas wherever possible (function arguments)
+		// - "es5" (default) Trailing commas where valid in ES5 (objects, arrays, etc)
+		// - "none"          No trailing commas
+		// - "all"           Trailing commas wherever possible (function arguments)
 		// --------------------------------------------------------------------
 
 		"trailingComma": "es5",
@@ -395,8 +395,10 @@
 		// @param {bool} "prettier_options.semi"
 		// @default true
 		//
-		// Whether to add a semicolon at the end of every line (semi: true), or
-		// only at the beginning of lines that may introduce ASI failures (semi: false)
+		// Valid options:
+		//
+		// - true (default)  Add a semicolon at the end of every statement.
+		// - false           Only add semicolons at the beginning of lines that may introduce ASI failures.
 		// --------------------------------------------------------------------
 
 		"semi": true,
@@ -423,17 +425,19 @@
 		// @param {string} "prettier_options.proseWrap"
 		// @default "preserve"
 		//
-		// (Markdown and YAML Only) By default, Prettier will wrap markdown text
-		// as-is since some services use a linebreak-sensitive renderer, e.g.
-		// GitHub comment and BitBucket. In some cases you may want to rely on
-		// SublimeText soft wrapping instead, so this option allows you to opt
-		// out with "never".
+		// (Markdown and YAML Only) By default, Prettier will not change
+		// wrapping in markdown text since some services use a
+		// linebreak-sensitive renderer, e.g. GitHub comments and BitBucket. To
+		// have Prettier wrap prose to the print width, change this option to
+		// "always". If you want Prettier to force all prose blocks to be on a
+		// single line and rely on editor/viewer soft wrapping instead, you can
+		// use "never".
 		//
 		// Valid options:
 		//
-		// "always" - Wrap prose if it exceeds the print width.
-		// "never" - Do not wrap prose.
-		// "preserve" (default) - Wrap prose as-is. available in v1.9.0+
+		// - "preserve" (default)  Wrap prose as-is.
+		// - "always"              Wrap prose if it exceeds the print width.
+		// - "never"               Do not wrap prose.
 		// --------------------------------------------------------------------
 
 		"proseWrap": "preserve",
@@ -449,8 +453,8 @@
 		//
 		// Valid Options:
 		//
-		// - "avoid" - Omit parentheses when possible. Example: `x => x`
-		// - "always" (default) - Always include parentheses. Example: `(x) => x`
+		// - "always" (default)  Always include parentheses. Example: `(x) => x`
+		// - "avoid"             Omit parentheses when possible. Example: `x => x`
 		// --------------------------------------------------------------------
 
 		"arrowParens": "always",
@@ -466,15 +470,15 @@
 		//
 		// Valid Options:
 		//
-		// - "css" (default) - Respect the default value of CSS display property.
-		// - "strict" - Whitespaces are considered sensitive.
-		// - "ignore" - Whitespaces are considered insensitive.
+		// - "css" (default)  Respect the default value of CSS display property.
+		// - "strict"         Whitespaces are considered sensitive.
+		// - "ignore"         Whitespaces are considered insensitive.
 		// --------------------------------------------------------------------
 
 		"htmlWhitespaceSensitivity": "css",
 
 		// --------------------------------------------------------------------
-		// Quote Props
+		// quoteProps
 		// --------------------------------------------------------------------
 		//
 		// @param {string} "prettier_options.quoteProps"
@@ -484,9 +488,9 @@
 		//
 		// Valid options:
 		//
-		// - "as-needed" (default) - Only add quotes around object properties where required.
-		// - "consistent" - If at least one property in an object requires quotes, quote all properties.
-		// - "preserve" - Respect the input use of quotes in object properties.
+		// - "as-needed" (default)  Only add quotes around object properties where required.
+		// - "consistent"           If at least one property in an object requires quotes, quote all properties.
+		// - "preserve"             Respect the input use of quotes in object properties.
 		// --------------------------------------------------------------------
 
 		"quoteProps": "as-needed",
@@ -505,8 +509,8 @@
 		//
 		// Valid Options:
 		//
-		// - false (default) - Do not indent script and style tags in Vue files.
-		// - true - Indent script and style tags in Vue files.
+		// - false (default)  Do not indent script and style tags in Vue files.
+		// - true             Indent script and style tags in Vue files.
 		// --------------------------------------------------------------------
 
 		"vueIndentScriptAndStyle": false,
@@ -532,8 +536,8 @@
 		//
 		// Valid Options:
 		//
-		// - "auto" (default) - Format embedded code if Prettier can automatically identify it.
-		// - "off" - Never automatically format embedded code.
+		// - "auto" (default)  Format embedded code if Prettier can automatically identify it.
+		// - "off"             Never automatically format embedded code.
 		// --------------------------------------------------------------------
 
 		"embeddedLanguageFormatting": "auto",
@@ -548,18 +552,41 @@
 		// Whether to take into account .editorconfig files when parsing
 		// configuration.
 		//
-		// If editorconfig is true and an .editorconfig file is in your
+		// If editorconfig is true, and an .editorconfig file is in your
 		// project, Prettier will parse it and convert its properties to the
 		// corresponding Prettier configuration. This configuration will be
-		// overridden by .prettierrc, etc. Currently, the following
-		// EditorConfig properties are supported:
+		// overridden by .prettierrc, etc.
+		//
+		// Currently, the following EditorConfig properties are supported:
 		//
 		// - end_of_line
 		// - indent_style
 		// - indent_size/tab_width
 		// - max_line_length
+		//
+		// Valid Options:
+		//
+		// - true (default)  If true, and an .editorconfig file is in your project, parse and convert its properties to the corresponding Prettier configuration.
+		// - false           Disable .editorconfig file support.
 		// --------------------------------------------------------------------
 
-		"editorconfig": true
+		"editorconfig": true,
+
+		// --------------------------------------------------------------------
+		// singleAttributePerLine
+		// --------------------------------------------------------------------
+		//
+		// @param {bool} "prettier_options.singleAttributePerLine"
+		// @default false
+		//
+		// Enforce single attribute per line in HTML, Vue and JSX.
+		//
+		// Valid Options:
+		//
+		// - false (default)  Do not enforce single attribute per line.
+		// - true 		      Enforce single attribute per line.
+		// --------------------------------------------------------------------
+
+		"singleAttributePerLine": false
 	}
 }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Operating Systems.
 - [Sublime Text] – Text editor for code
 - [node.js] – JavaScript runtime
     - [yarn] or [npm] – Package manager for JavaScript
-        - [Prettier] – Opinionated code formatter (v2.4 or above)
+        - [Prettier] – Opinionated code formatter (v2.6 or above)
 
 ### Install Prettier
 
@@ -443,6 +443,14 @@ application menu to:
     - `indent_style`
     - `indent_size/tab_width`
     - `max_line_length`
+    
+- **singleAttributePerLine** (default: ***false***)  
+    Enforce single attribute per line in HTML, Vue and JSX.
+
+    Valid Options:
+
+    - ***false*** (default) Do not enforce single attribute per line.
+    - ***true*** Enforce single attribute per line.
 
 See the Prettier Options [doc page] for more details and examples.
 
@@ -493,7 +501,8 @@ you'll need to add a new `js_prettier` key and section under `settings`, as [see
                 "quoteProps": "as-needed",
                 "vueIndentScriptAndStyle": false,
                 "embeddedLanguageFormatting": "auto",
-                "editorconfig": true
+                "editorconfig": true,
+                "singleAttributePerLine": false
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ application menu to:
     - `indent_style`
     - `indent_size/tab_width`
     - `max_line_length`
-    
+
 - **singleAttributePerLine** (default: ***false***)  
     Enforce single attribute per line in HTML, Vue and JSX.
 
@@ -456,7 +456,8 @@ See the Prettier Options [doc page] for more details and examples.
 
 ### Project-level Settings
 
-JsPrettier supports [project-level settings], specified in `<project_name>.sublime-project` files.
+JsPrettier supports [project-level settings], specified in
+`project_name.sublime-project` files.
 
 In order for your project-level settings to override [previous configurations](#settings),
 you'll need to add a new `js_prettier` key and section under `settings`, as [seen below].

--- a/README.md
+++ b/README.md
@@ -456,8 +456,7 @@ See the Prettier Options [doc page] for more details and examples.
 
 ### Project-level Settings
 
-JsPrettier supports [project-level settings], specified in
-`project_name.sublime-project` files.
+JsPrettier supports [project-level settings], specified in `<project_name>.sublime-project` files.
 
 In order for your project-level settings to override [previous configurations](#settings),
 you'll need to add a new `js_prettier` key and section under `settings`, as [seen below].

--- a/jsprettier/const.py
+++ b/jsprettier/const.py
@@ -126,6 +126,11 @@ PRETTIER_OPTION_CLI_MAP = [
         'option': 'editorconfig',
         'cli': '--editorconfig',
         'default': 'true'
+    },
+    {
+        'option': 'singleAttributePerLine',
+        'cli': '--single-attribute-per-line',
+        'default': 'false'
     }
 ]
 

--- a/messages.json
+++ b/messages.json
@@ -41,5 +41,6 @@
   "1.30.0": "messages/1.30.0.txt",
   "1.31.0": "messages/1.31.0.txt",
   "1.38.0": "messages/1.38.0.txt",
-  "1.50.0": "messages/1.50.0.txt"
+  "1.50.0": "messages/1.50.0.txt",
+  "1.60.0": "messages/1.60.0.txt"
 }

--- a/messages/1.60.0.txt
+++ b/messages/1.60.0.txt
@@ -1,0 +1,16 @@
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                     _     ____           _   _   _                           │
+│                    | |___|  _ \ _ __ ___| |_| |_(_) ___ _ __                 │
+│                 _  | / __| |_) | '__/ _ \ __| __| |/ _ \ '__|                │
+│                | |_| \__ \  __/| | |  __/ |_| |_| |  __/ |                   │
+│                 \___/|___/_|   |_|  \___|\__|\__|_|\___|_|                   │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+
+## 1.60.0
+
+Added setting to support new singleAttributePerLine option, which can force each
+attribute to be placed on a single line in HTML, Vue and JSX.
+
+- [Single Line Attribute](https://prettier.io/docs/en/options.html#single-attribute-per-line)
+- [Prettier 2.6: new singleAttributePerLine option and new JavaScript features!](https://prettier.io/blog/2022/03/16/2.6.0.html#enforce-single-attribute-per-line-6644httpsgithubcomprettierprettierpull6644-by-kankjehttpsgithubcomkankje)


### PR DESCRIPTION
Add [setting](https://github.com/jonlabelle/SublimeJsPrettier/blob/master/JsPrettier.sublime-settings) to support new [singleAttributePerLine](https://prettier.io/blog/2022/03/16/2.6.0.html#enforce-single-attribute-per-line-6644httpsgithubcomprettierprettierpull6644-by-kankjehttpsgithubcomkankje) option.

*First [available](https://prettier.io/docs/en/options.html#single-attribute-per-line) in v2.6.0*

Closes #252