### PR TITLE
Support scss parser

### DIFF
--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -461,6 +461,8 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
             return True
         if self.is_less(view) is True:
             return True
+        if self.is_scss(view) is True:
+            return True
         if self.is_css(view) is True:
             return True
         if self.is_angular_html(view) is True:
@@ -557,6 +559,10 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
                 elif self.is_less(view):
                     prettier_options.append(cli_option_name)
                     prettier_options.append('less')
+                    continue
+                elif self.is_scss(view):
+                    prettier_options.append(cli_option_name)
+                    prettier_options.append('scss')
                     continue
                 elif self.is_css(view):
                     prettier_options.append(cli_option_name)
@@ -671,6 +677,16 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
         return False
 
     @staticmethod
+    def is_scss(view):
+        filename = view.file_name()
+        if not filename:
+            return False
+        scopename = view.scope_name(view.sel()[0].b)
+        if scopename.startswith('source.scss') or filename.endswith('.scss'):
+            return True
+        return False
+
+    @staticmethod
     def is_css(view):
         filename = view.file_name()
         if not filename:
@@ -678,8 +694,6 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
         scopename = view.scope_name(view.sel()[0].b)
         if scopename.startswith('source.css') or filename.endswith('.css') \
                 or contains('meta.selector.css', scopename) or contains('source.css.embedded.html', scopename):
-            return True
-        if scopename.startswith('source.scss') or filename.endswith('.scss'):
             return True
         return False
 


### PR DESCRIPTION
Files with the `.scss` extension are currently being parsed using the `css` parser (instead of the `scss` parser), which causes failures in some situations where code is valid `scss` but invalid `css`. An example of this is the following snippet of valid `scss`:

```scss
/*
 * Example SASS
 */

// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
// Imports

@import "colors";
@import "fonts";

// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
// Classes

.some-class-a {
    &.class-b {
            color: red;
    }
}

```

If you attempt have SublimeJsPrettier format the above code, you end up with the following error in the Sublime console:

```
------------------
 JsPrettier ERROR 
------------------

Prettier reported the following output:

[error] /test.scss: SyntaxError: CssSyntaxError: Unknown word (5:1)
[error]   3 |  */
[error]   4 |
[error] > 5 | // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[error]     | ^
[error]   6 | // Imports
[error]   7 |
[error]   8 | @import "colors";


Prettier process finished with exit code 2.
```

However, copying and pasting into the [Prettier Playground](https://prettier.io/playground) and selecting the `scss` `--parser` option, the file is prettified properly (selecting the `css` option reports the same error as SublimeJsPrettier).

This pull request attempts to properly determine if a file is SASS (by looking for the `scss` extension) and assigning the correct `scss` option. 