### PR TITLE
Use correct working directory so Prettier is able to find plugins

### DIFF
--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -275,6 +275,11 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
             prettier_ignore_filepath, source_file_path)
 
         #
+        # change to appropriate directory
+        if prettier_cli_path in st_project_path and 'node_modules' in prettier_cli_path:
+            os.chdir(os.path.dirname(prettier_cli_path[:prettier_cli_path.index('node_modules')]))
+
+        #
         # Format entire file:
         if not has_selection(view) or save_file is True:
             region = sublime.Region(0, view.size())

--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -275,9 +275,11 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
             prettier_ignore_filepath, source_file_path)
 
         #
-        # change to appropriate directory
-        if prettier_cli_path in st_project_path and 'node_modules' in prettier_cli_path:
-            os.chdir(os.path.dirname(prettier_cli_path[:prettier_cli_path.index('node_modules')]))
+        # change to appropriate working directory
+        if st_project_path in prettier_cli_path and 'node_modules' in prettier_cli_path:
+            working_directory_path = os.path.dirname(prettier_cli_path[:prettier_cli_path.index('node_modules')])
+            log_debug(view, "Setting working directory to {0}".format(working_directory_path))
+            os.chdir(working_directory_path)
 
         #
         # Format entire file:


### PR DESCRIPTION
If Prettier installed in the Sublime project is used, the working directory must be set up so Prettier can find plugins. We can assume the plugins will be in the same `node_modules` directory.