### PR TITLE
Wrap stdin-filepath in quotes

### DIFF
--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -636,7 +636,7 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
         # detect and format css/js selection(s) within html files:
         # if not self.is_html(view):
         prettier_options.append('--stdin-filepath')
-        prettier_options.append(source_file_path)
+        prettier_options.append('"' + source_file_path + '"')
 
         if debug_enabled(view):
             if not parsed_additional_cli_args.count('--log-level') > 0:


### PR DESCRIPTION
Resolves #285

Stripping the path prefix as mentioned in https://github.com/jonlabelle/SublimeJsPrettier/issues/285#issuecomment-2078388482 would have also fixed this particular issue, but I think it's best to wrap in quotes to support parentheses in the filename. Also having the full path should help with debugging?