### PR TITLE
config(prettier): --config option renamed to --config-path

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -67,7 +67,7 @@ body:
     attributes:
       label: Prettier command
       description: Generated `prettier` command line arguments. [Enable debug mode](https://github.com/jonlabelle/SublimeJsPrettier/blob/master/JsPrettier.sublime-settings#L18 "Go to debug option in JsPrettier.sublime-settings") and open the [console](https://docs.sublimetext.io/guide/getting-started/basic-concepts.html#the-console "Read more about the SublimeText console") to view.
-      placeholder: prettier --config ./prettierrc --stdin-filepath messy.js
+      placeholder: prettier --config-path ./prettierrc --stdin-filepath messy.js
       render: console
     validations:
       required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 1.91.0
+
+**Release Date:** 2026-03-19
+
+This release updates the plugin to match Prettier's CLI rename of `--config` to `--config-path`.
+
+You will need to update your plugin setting for `additional_cli_args` (JsPrettier.sublime-settings)
+if you were previously specifying `--config` to point to a custom Prettier configuration file.
+
+For example, if you had:
+
+```json
+"additional_cli_args": ["--config", "path/to/prettier/.prettierrc"]
+```
+
+You should update it to:
+
+```json
+"additional_cli_args": ["--config-path", "path/to/prettier/.prettierrc"]
+```
+
 ## 1.90.0
 
 **Release Date:** 2025-10-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,26 +4,14 @@
 
 **Release Date:** 2026-03-19
 
-This release updates the plugin to match Prettier's CLI rename of `--config` to `--config-path`.
+This release adds support for Prettier's `--config-path` CLI option, introduced in Prettier's
+experimental CLI (`--experimental-cli`).
 
-You will need to update your plugin setting for `additional_cli_args` (JsPrettier.sublime-settings)
-if you were previously specifying `--config` to point to a custom Prettier configuration file.
+When `--experimental-cli` is present in `additional_cli_args`, the plugin automatically uses
+`--config-path` to pass the resolved config file path to Prettier. Otherwise, the classic `--config`
+flag is used. **No changes to your settings are required.**
 
-For example, if you had:
-
-```json
-"additional_cli_args": {
-  "--config": "path/to/prettier/.prettierrc"
-}
-```
-
-You should update it to:
-
-```json
-"additional_cli_args": {
-  "--config-path": "path/to/prettier/.prettierrc"
-}
-```
+Both `--config` and `--config-path` are accepted as keys in the `additional_cli_args` setting.
 
 ## 1.90.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,17 @@ if you were previously specifying `--config` to point to a custom Prettier confi
 For example, if you had:
 
 ```json
-"additional_cli_args": ["--config", "path/to/prettier/.prettierrc"]
+"additional_cli_args": {
+  "--config": "path/to/prettier/.prettierrc"
+}
 ```
 
 You should update it to:
 
 ```json
-"additional_cli_args": ["--config-path", "path/to/prettier/.prettierrc"]
+"additional_cli_args": {
+  "--config-path": "path/to/prettier/.prettierrc"
+}
 ```
 
 ## 1.90.0

--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -805,7 +805,7 @@ class CommandOnSave(sublime_plugin.EventListener):
 
         #
         # 1. Check if defined in 'additional_cli_args':
-        additional_cli_arg_config = get_cli_arg_value(self.get_additional_cli_args(view), '--config-path')
+        additional_cli_arg_config = self.get_additional_cli_args(view).get('--config-path')
         if not is_str_none_or_empty(additional_cli_arg_config):
             additional_cli_arg_config = os.path.normpath(additional_cli_arg_config)
             if not os.path.isabs(additional_cli_arg_config):

--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -168,7 +168,7 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
 
         #
         # 1. Check if defined in 'additional_cli_args':
-        additional_cli_arg_config = get_cli_arg_value(self.additional_cli_args, '--config-path')
+        additional_cli_arg_config = self.additional_cli_args.get('--config-path')
         if not is_str_none_or_empty(additional_cli_arg_config):
             additional_cli_arg_config = os.path.normpath(additional_cli_arg_config)
             if not os.path.isabs(additional_cli_arg_config):

--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -45,7 +45,6 @@ if version_info[0] == 2:
     from jsprettier.util import find_prettier_config
     from jsprettier.util import format_debug_message
     from jsprettier.util import format_error_message
-    from jsprettier.util import get_cli_arg_value
     from jsprettier.util import get_file_abs_dir
     from jsprettier.util import get_proc_env
     from jsprettier.util import in_source_file_path_or_project_root
@@ -89,7 +88,6 @@ else:
     from .jsprettier.util import find_prettier_config
     from .jsprettier.util import format_debug_message
     from .jsprettier.util import format_error_message
-    from .jsprettier.util import get_cli_arg_value
     from .jsprettier.util import get_file_abs_dir
     from .jsprettier.util import get_proc_env
     from .jsprettier.util import in_source_file_path_or_project_root
@@ -145,7 +143,10 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
 
     @property
     def additional_cli_args(self):
-        return get_setting(self.view, 'additional_cli_args', {})
+        additional_cli_args = get_setting(self.view, 'additional_cli_args', {})
+        if isinstance(additional_cli_args, dict):
+            return additional_cli_args
+        return {}
 
     @property
     def max_file_size_limit(self):
@@ -162,14 +163,43 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
             return True
         return False
 
+    @staticmethod
+    def get_additional_cli_arg_config(additional_cli_args):
+        if not isinstance(additional_cli_args, dict):
+            return None
+        arg_value = additional_cli_args.get('--config-path') or additional_cli_args.get('--config')
+        if not is_str_none_or_empty(arg_value):
+            return arg_value
+        return None
+
+    @staticmethod
+    def has_config_cli_arg(parsed_additional_cli_args):
+        return parsed_additional_cli_args.count('--config-path') > 0 or parsed_additional_cli_args.count('--config') > 0
+
+    def run_prettier_process(self, cmd, source, view):
+        format_debug_message('Prettier CLI Command', list_to_str(cmd), debug_enabled(view))
+
+        proc = Popen(
+            cmd,
+            stdin=PIPE,
+            stderr=PIPE,
+            stdout=PIPE,
+            env=get_proc_env(),
+            shell=is_windows()
+        )
+
+        stdout, stderr = proc.communicate(input=source.encode('utf-8'))
+        return proc.returncode, stdout, stderr
+
     def try_find_prettier_config(self, view):
         source_file_dir = get_file_abs_dir(view.file_name())
         st_project_path = get_st_project_path()
 
         #
         # 1. Check if defined in 'additional_cli_args':
-        additional_cli_arg_config = self.additional_cli_args.get('--config-path')
+        additional_cli_arg_config = self.get_additional_cli_arg_config(self.additional_cli_args)
         if not is_str_none_or_empty(additional_cli_arg_config):
+            additional_cli_arg_config = str(additional_cli_arg_config)
             additional_cli_arg_config = os.path.normpath(additional_cli_arg_config)
             if not os.path.isabs(additional_cli_arg_config):
                 additional_cli_arg_config = in_source_file_path_or_project_root(
@@ -234,15 +264,16 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
         os.chdir(st_project_path)
 
         #
-        # if a `--config-path <path>` option is set in 'additional_cli_args',
-        # no action is necessary. otherwise, try to sniff the config
-        # file path:
+        # if a `--config-path <path>` or `--config <path>` option is set in
+        # 'additional_cli_args', no action is necessary. otherwise, try to
+        # sniff the config file path:
         parsed_additional_cli_args = parse_additional_cli_args(view.window(), self.additional_cli_args)
-        has_custom_config_defined = parsed_additional_cli_args.count('--config-path') > 0
+        has_custom_config_defined = self.has_config_cli_arg(parsed_additional_cli_args)
         has_no_config_defined = parsed_additional_cli_args.count('--no-config') > 0
 
         prettier_config_path = None
-        # only try to resolve prettier config if '--no-config' or '--config-path' are NOT in 'additional_cli_args'
+        # only try to resolve prettier config if '--no-config', '--config-path',
+        # or '--config' are NOT in 'additional_cli_args'
         if not has_no_config_defined and not has_custom_config_defined:
             if save_file and auto_format_prettier_config_path and os.path.exists(auto_format_prettier_config_path):
                 prettier_config_path = auto_format_prettier_config_path
@@ -414,21 +445,10 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
                 + prettier_options
 
         try:
-            format_debug_message('Prettier CLI Command', list_to_str(cmd), debug_enabled(view))
-
-            proc = Popen(
-                cmd,
-                stdin=PIPE,
-                stderr=PIPE,
-                stdout=PIPE,
-                env=get_proc_env(),
-                shell=is_windows()
-            )
-
-            stdout, stderr = proc.communicate(input=source.encode('utf-8'))
-            if proc.returncode != 0:
+            return_code, stdout, stderr = self.run_prettier_process(cmd, source, view)
+            if return_code != 0:
                 error_output = normalize_line_endings(decode_bytes(stderr))
-                self.error_message = format_error_message(error_output, str(proc.returncode))
+                self.error_message = format_error_message(error_output, str(return_code))
 
                 # detect and scroll to 'Syntax Errors' (if not formatting a selection):
                 if not is_selection:
@@ -447,15 +467,18 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
 
                 # allow warnings to pass-through
                 if stderr_output:
-                    print(format_error_message(stderr_output, str(proc.returncode)))
+                    print(format_error_message(stderr_output, str(return_code)))
 
             if provide_cursor:
                 if not new_cursor and cursor is not None:
                     new_cursor = cursor
+                if new_cursor is None:
+                    log_warn('Adjusted cursor position could not be parsed.')
+                    return normalize_line_endings(decode_bytes(stdout)), None
                 try:
                     new_cursor = int(new_cursor)
-                except ValueError:
-                    log_warn(view, 'Adjusted cursor position could not be parsed.')
+                except (TypeError, ValueError):
+                    log_warn('Adjusted cursor position could not be parsed.')
                     return normalize_line_endings(decode_bytes(stdout)), None
                 return normalize_line_endings(decode_bytes(stdout)), new_cursor
 
@@ -509,9 +532,11 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
         prettier_config_exists = not is_str_none_or_empty(prettier_config_path)
         if prettier_config_exists:
             if not has_custom_config_defined:
-                # only add the '--config-path <path>' option if it's not
-                # already specified as an additional cli arg:
-                prettier_options.append('--config-path')
+                # use '--config-path' only when '--experimental-cli' is active (Prettier 3+),
+                # otherwise fall back to '--config':
+                use_experimental_cli = parsed_additional_cli_args.count('--experimental-cli') > 0
+                config_flag = '--config-path' if use_experimental_cli else '--config'
+                prettier_options.append(config_flag)
                 prettier_options.append(prettier_config_path)
 
         else:
@@ -805,8 +830,10 @@ class CommandOnSave(sublime_plugin.EventListener):
 
         #
         # 1. Check if defined in 'additional_cli_args':
-        additional_cli_arg_config = self.get_additional_cli_args(view).get('--config-path')
+        additional_cli_arg_config = JsPrettierCommand.get_additional_cli_arg_config(
+            self.get_additional_cli_args(view))
         if not is_str_none_or_empty(additional_cli_arg_config):
+            additional_cli_arg_config = str(additional_cli_arg_config)
             additional_cli_arg_config = os.path.normpath(additional_cli_arg_config)
             if not os.path.isabs(additional_cli_arg_config):
                 additional_cli_arg_config = in_source_file_path_or_project_root(
@@ -845,7 +872,10 @@ class CommandOnSave(sublime_plugin.EventListener):
 
     @staticmethod
     def get_additional_cli_args(view):
-        return dict(get_setting(view, 'additional_cli_args', {}))
+        additional_cli_args = get_setting(view, 'additional_cli_args', {})
+        if isinstance(additional_cli_args, dict):
+            return additional_cli_args
+        return {}
 
     def is_enabled(self, view):
         return self.get_auto_format_on_save(view)

--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -245,7 +245,8 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
         has_no_config_defined = parsed_additional_cli_args.count('--no-config') > 0
 
         prettier_config_path = None
-        # only try to resolve prettier config if '--no-config', '--config-path', or '--config' are NOT in 'additional_cli_args'
+        # only try to resolve prettier config if '--no-config', '--config-path',
+        # or '--config' are NOT in 'additional_cli_args'
         if not has_no_config_defined and not has_custom_config_defined:
             if save_file and auto_format_prettier_config_path and os.path.exists(auto_format_prettier_config_path):
                 prettier_config_path = auto_format_prettier_config_path

--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -45,6 +45,7 @@ if version_info[0] == 2:
     from jsprettier.util import find_prettier_config
     from jsprettier.util import format_debug_message
     from jsprettier.util import format_error_message
+    from jsprettier.util import get_cli_arg_value
     from jsprettier.util import get_file_abs_dir
     from jsprettier.util import get_proc_env
     from jsprettier.util import in_source_file_path_or_project_root
@@ -88,6 +89,7 @@ else:
     from .jsprettier.util import find_prettier_config
     from .jsprettier.util import format_debug_message
     from .jsprettier.util import format_error_message
+    from .jsprettier.util import get_cli_arg_value
     from .jsprettier.util import get_file_abs_dir
     from .jsprettier.util import get_proc_env
     from .jsprettier.util import in_source_file_path_or_project_root
@@ -143,10 +145,7 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
 
     @property
     def additional_cli_args(self):
-        additional_cli_args = get_setting(self.view, 'additional_cli_args', {})
-        if isinstance(additional_cli_args, dict):
-            return additional_cli_args
-        return {}
+        return get_setting(self.view, 'additional_cli_args', {})
 
     @property
     def max_file_size_limit(self):
@@ -163,41 +162,14 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
             return True
         return False
 
-    @staticmethod
-    def get_additional_cli_arg_config(additional_cli_args):
-        if not isinstance(additional_cli_args, dict):
-            return None
-        arg_value = additional_cli_args.get('--config-path') or additional_cli_args.get('--config')
-        if not is_str_none_or_empty(arg_value):
-            return arg_value
-        return None
-
-    @staticmethod
-    def has_config_cli_arg(parsed_additional_cli_args):
-        return parsed_additional_cli_args.count('--config-path') > 0 or parsed_additional_cli_args.count('--config') > 0
-
-    def run_prettier_process(self, cmd, source, view):
-        format_debug_message('Prettier CLI Command', list_to_str(cmd), debug_enabled(view))
-
-        proc = Popen(
-            cmd,
-            stdin=PIPE,
-            stderr=PIPE,
-            stdout=PIPE,
-            env=get_proc_env(),
-            shell=is_windows()
-        )
-
-        stdout, stderr = proc.communicate(input=source.encode('utf-8'))
-        return proc.returncode, stdout, stderr
-
     def try_find_prettier_config(self, view):
         source_file_dir = get_file_abs_dir(view.file_name())
         st_project_path = get_st_project_path()
 
         #
         # 1. Check if defined in 'additional_cli_args':
-        additional_cli_arg_config = self.get_additional_cli_arg_config(self.additional_cli_args)
+        additional_cli_arg_config = get_cli_arg_value(self.additional_cli_args, '--config-path') \
+            or get_cli_arg_value(self.additional_cli_args, '--config')
         if not is_str_none_or_empty(additional_cli_arg_config):
             additional_cli_arg_config = str(additional_cli_arg_config)
             additional_cli_arg_config = os.path.normpath(additional_cli_arg_config)
@@ -268,12 +240,12 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
         # 'additional_cli_args', no action is necessary. otherwise, try to
         # sniff the config file path:
         parsed_additional_cli_args = parse_additional_cli_args(view.window(), self.additional_cli_args)
-        has_custom_config_defined = self.has_config_cli_arg(parsed_additional_cli_args)
+        has_custom_config_defined = parsed_additional_cli_args.count('--config-path') > 0 \
+            or parsed_additional_cli_args.count('--config') > 0
         has_no_config_defined = parsed_additional_cli_args.count('--no-config') > 0
 
         prettier_config_path = None
-        # only try to resolve prettier config if '--no-config', '--config-path',
-        # or '--config' are NOT in 'additional_cli_args'
+        # only try to resolve prettier config if '--no-config', '--config-path', or '--config' are NOT in 'additional_cli_args'
         if not has_no_config_defined and not has_custom_config_defined:
             if save_file and auto_format_prettier_config_path and os.path.exists(auto_format_prettier_config_path):
                 prettier_config_path = auto_format_prettier_config_path
@@ -445,10 +417,21 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
                 + prettier_options
 
         try:
-            return_code, stdout, stderr = self.run_prettier_process(cmd, source, view)
-            if return_code != 0:
+            format_debug_message('Prettier CLI Command', list_to_str(cmd), debug_enabled(view))
+
+            proc = Popen(
+                cmd,
+                stdin=PIPE,
+                stderr=PIPE,
+                stdout=PIPE,
+                env=get_proc_env(),
+                shell=is_windows()
+            )
+
+            stdout, stderr = proc.communicate(input=source.encode('utf-8'))
+            if proc.returncode != 0:
                 error_output = normalize_line_endings(decode_bytes(stderr))
-                self.error_message = format_error_message(error_output, str(return_code))
+                self.error_message = format_error_message(error_output, str(proc.returncode))
 
                 # detect and scroll to 'Syntax Errors' (if not formatting a selection):
                 if not is_selection:
@@ -467,18 +450,15 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
 
                 # allow warnings to pass-through
                 if stderr_output:
-                    print(format_error_message(stderr_output, str(return_code)))
+                    print(format_error_message(stderr_output, str(proc.returncode)))
 
             if provide_cursor:
                 if not new_cursor and cursor is not None:
                     new_cursor = cursor
-                if new_cursor is None:
-                    log_warn('Adjusted cursor position could not be parsed.')
-                    return normalize_line_endings(decode_bytes(stdout)), None
                 try:
                     new_cursor = int(new_cursor)
-                except (TypeError, ValueError):
-                    log_warn('Adjusted cursor position could not be parsed.')
+                except ValueError:
+                    log_warn(view, 'Adjusted cursor position could not be parsed.')
                     return normalize_line_endings(decode_bytes(stdout)), None
                 return normalize_line_endings(decode_bytes(stdout)), new_cursor
 
@@ -830,8 +810,8 @@ class CommandOnSave(sublime_plugin.EventListener):
 
         #
         # 1. Check if defined in 'additional_cli_args':
-        additional_cli_arg_config = JsPrettierCommand.get_additional_cli_arg_config(
-            self.get_additional_cli_args(view))
+        additional_cli_arg_config = get_cli_arg_value(self.get_additional_cli_args(view), '--config-path') \
+            or get_cli_arg_value(self.get_additional_cli_args(view), '--config')
         if not is_str_none_or_empty(additional_cli_arg_config):
             additional_cli_arg_config = str(additional_cli_arg_config)
             additional_cli_arg_config = os.path.normpath(additional_cli_arg_config)
@@ -872,10 +852,7 @@ class CommandOnSave(sublime_plugin.EventListener):
 
     @staticmethod
     def get_additional_cli_args(view):
-        additional_cli_args = get_setting(view, 'additional_cli_args', {})
-        if isinstance(additional_cli_args, dict):
-            return additional_cli_args
-        return {}
+        return dict(get_setting(view, 'additional_cli_args', {}))
 
     def is_enabled(self, view):
         return self.get_auto_format_on_save(view)

--- a/JsPrettier.py
+++ b/JsPrettier.py
@@ -168,7 +168,7 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
 
         #
         # 1. Check if defined in 'additional_cli_args':
-        additional_cli_arg_config = get_cli_arg_value(self.additional_cli_args, '--config')
+        additional_cli_arg_config = get_cli_arg_value(self.additional_cli_args, '--config-path')
         if not is_str_none_or_empty(additional_cli_arg_config):
             additional_cli_arg_config = os.path.normpath(additional_cli_arg_config)
             if not os.path.isabs(additional_cli_arg_config):
@@ -234,15 +234,15 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
         os.chdir(st_project_path)
 
         #
-        # if a `--config <path>` option is set in 'additional_cli_args',
+        # if a `--config-path <path>` option is set in 'additional_cli_args',
         # no action is necessary. otherwise, try to sniff the config
         # file path:
         parsed_additional_cli_args = parse_additional_cli_args(view.window(), self.additional_cli_args)
-        has_custom_config_defined = parsed_additional_cli_args.count('--config') > 0
+        has_custom_config_defined = parsed_additional_cli_args.count('--config-path') > 0
         has_no_config_defined = parsed_additional_cli_args.count('--no-config') > 0
 
         prettier_config_path = None
-        # only try to resolve prettier config if '--no-config' or '--config' are NOT in 'additional_cli_args'
+        # only try to resolve prettier config if '--no-config' or '--config-path' are NOT in 'additional_cli_args'
         if not has_no_config_defined and not has_custom_config_defined:
             if save_file and auto_format_prettier_config_path and os.path.exists(auto_format_prettier_config_path):
                 prettier_config_path = auto_format_prettier_config_path
@@ -509,9 +509,9 @@ class JsPrettierCommand(sublime_plugin.TextCommand):
         prettier_config_exists = not is_str_none_or_empty(prettier_config_path)
         if prettier_config_exists:
             if not has_custom_config_defined:
-                # only add the '--config <path>' option if it's not
+                # only add the '--config-path <path>' option if it's not
                 # already specified as an additional cli arg:
-                prettier_options.append('--config')
+                prettier_options.append('--config-path')
                 prettier_options.append(prettier_config_path)
 
         else:
@@ -805,7 +805,7 @@ class CommandOnSave(sublime_plugin.EventListener):
 
         #
         # 1. Check if defined in 'additional_cli_args':
-        additional_cli_arg_config = get_cli_arg_value(self.get_additional_cli_args(view), '--config')
+        additional_cli_arg_config = get_cli_arg_value(self.get_additional_cli_args(view), '--config-path')
         if not is_str_none_or_empty(additional_cli_arg_config):
             additional_cli_arg_config = os.path.normpath(additional_cli_arg_config)
             if not os.path.isabs(additional_cli_arg_config):

--- a/JsPrettier.sublime-settings
+++ b/JsPrettier.sublime-settings
@@ -128,10 +128,11 @@
 	//
 	// Enable auto format on save ONLY when a Prettier config file is found.
 	//
-	// The Prettier config file is resolved by first checking if a `--config-path </path/to/prettier/config>`
-	// is specified in the `additional_cli_args` setting, then by searching the
-	// location of the file being formatted, and finally navigating up the file
-	// tree until a config file is (or isn't) found.
+	// The Prettier config file is resolved by first checking if a `--config-path <path>` or
+	// `--config <path>` is specified in the `additional_cli_args` setting, then by searching
+	// the location of the file being formatted, and finally navigating up the file
+	// tree until a config file is (or isn't) found. When `--experimental-cli` is present
+	// in `additional_cli_args`, `--config-path` is used; otherwise `--config` is used.
 	// ----------------------------------------------------------------------
 
 	"auto_format_on_save_requires_prettier_config": false,
@@ -243,7 +244,8 @@
 	// Examples:
 	//
 	//     "additional_cli_args": {
-	//         "--config-path": "path/to/my/custom/.prettierrc",
+	//         "--config-path": "path/to/my/custom/.prettierrc",  // use with --experimental-cli
+	//         "--config": "path/to/my/custom/.prettierrc",       // classic Prettier (no --experimental-cli)
 	//         "--config-path": "~/.prettierrc",
 	//         "--config-path": "$HOME/.prettierrc",
 	//         "--config-path": "${project_path}/.prettierrc",

--- a/JsPrettier.sublime-settings
+++ b/JsPrettier.sublime-settings
@@ -128,7 +128,7 @@
 	//
 	// Enable auto format on save ONLY when a Prettier config file is found.
 	//
-	// The Prettier config file is resolved by first checking if a `--config </path/to/prettier/config>`
+	// The Prettier config file is resolved by first checking if a `--config-path </path/to/prettier/config>`
 	// is specified in the `additional_cli_args` setting, then by searching the
 	// location of the file being formatted, and finally navigating up the file
 	// tree until a config file is (or isn't) found.
@@ -243,10 +243,10 @@
 	// Examples:
 	//
 	//     "additional_cli_args": {
-	//         "--config": "path/to/my/custom/.prettierrc",
-	//         "--config": "~/.prettierrc",
-	//         "--config": "$HOME/.prettierrc",
-	//         "--config": "${project_path}/.prettierrc",
+	//         "--config-path": "path/to/my/custom/.prettierrc",
+	//         "--config-path": "~/.prettierrc",
+	//         "--config-path": "$HOME/.prettierrc",
+	//         "--config-path": "${project_path}/.prettierrc",
 	//         "--config-precedence": "prefer-file",
 	//         "--ignore-path": "${file_path}/.prettierignore",
 	//         "--with-node-modules": "",

--- a/README.md
+++ b/README.md
@@ -237,10 +237,11 @@ Configure plugin settings and Prettier options via the application menu:
     Enable auto format on save *only* when a Prettier config file is (or isn't)
     found.
 
-    The Prettier config file is resolved by first checking if a `--config-path </path/to/prettier/config>`
+    The Prettier config file is resolved by first checking if a `--config-path <path>` or `--config <path>`
     is specified in the `additional_cli_args` setting, then by searching the
     location of the file being formatted, and finally navigating up the file tree
-    until a config file is (or isn't) found.
+    until a config file is (or isn't) found. When `--experimental-cli` is present
+    in `additional_cli_args`, the plugin uses `--config-path`; otherwise `--config` is used.
 
 - **allow_inline_formatting** (default: ***false***)  
     Enables the ability to format *selections* of in-lined code. For example, to
@@ -292,7 +293,9 @@ Configure plugin settings and Prettier options via the application menu:
     ```jsonc
     {
         "additional_cli_args": {
-            "--config-path": "~/.prettierrc",
+            "--config-path": "~/.prettierrc",  // use with --experimental-cli
+            // or
+            "--config": "~/.prettierrc",       // classic Prettier (no --experimental-cli)
             // or
             "--config-path": "$HOME/.prettierrc",
             // or
@@ -528,8 +531,9 @@ or selection(s) defined in Sublime Text.
 
 #### Custom Prettier Config File Path
 
-To specify a custom Prettier config path, simply add a `--config-path <path>`
-key-value item to `additional_cli_args`. Here's an example:
+To specify a custom Prettier config path, add `--config-path <path>` (when using
+`--experimental-cli`) or `--config <path>` (classic Prettier) as a key-value item in
+`additional_cli_args`. Both keys are accepted by the plugin. Here's an example:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Configure plugin settings and Prettier options via the application menu:
     Enable auto format on save *only* when a Prettier config file is (or isn't)
     found.
 
-    The Prettier config file is resolved by first checking if a `--config </path/to/prettier/config>`
+    The Prettier config file is resolved by first checking if a `--config-path </path/to/prettier/config>`
     is specified in the `additional_cli_args` setting, then by searching the
     location of the file being formatted, and finally navigating up the file tree
     until a config file is (or isn't) found.
@@ -292,13 +292,13 @@ Configure plugin settings and Prettier options via the application menu:
     ```jsonc
     {
         "additional_cli_args": {
-            "--config": "~/.prettierrc",
+            "--config-path": "~/.prettierrc",
             // or
-            "--config": "$HOME/.prettierrc",
+            "--config-path": "$HOME/.prettierrc",
             // or
-            "--config": "${project_path}/.prettierrc",
+            "--config-path": "${project_path}/.prettierrc",
             // or
-            "--config": "/some/absolute/path/to/.prettierrc",
+            "--config-path": "/some/absolute/path/to/.prettierrc",
 
             "--config-precedence": "file-override",
             "--ignore-path": "${file_path}/.prettierignore",
@@ -528,13 +528,13 @@ or selection(s) defined in Sublime Text.
 
 #### Custom Prettier Config File Path
 
-To specify a custom Prettier config path, simply add a `--config <path>`
+To specify a custom Prettier config path, simply add a `--config-path <path>`
 key-value item to `additional_cli_args`. Here's an example:
 
 ```json
 {
     "additional_cli_args": {
-        "--config": "~/some/path/from/my/home/.prettierrc",
+        "--config-path": "~/some/path/from/my/home/.prettierrc",
         "--config-precedence": "prefer-file",
         "--ignore-path": "${project_path}/.prettierignore"
     }

--- a/messages.json
+++ b/messages.json
@@ -47,5 +47,6 @@
   "1.64.0": "messages/1.64.0.txt",
   "1.65.0": "messages/1.65.0.txt",
   "1.70.0": "messages/1.70.0.txt",
-  "1.90.0": "messages/1.90.0.txt"
+  "1.90.0": "messages/1.90.0.txt",
+  "1.91.0": "messages/1.91.0.txt"
 }

--- a/messages/1.91.0.txt
+++ b/messages/1.91.0.txt
@@ -19,11 +19,19 @@ if you were previously specifying `--config` to point to a custom Prettier confi
 For example, if you had:
 
 ```json
-"additional_cli_args": ["--config", "path/to/prettier/.prettierrc"]
+{
+  "additional_cli_args": {
+    "--config": "path/to/prettier/.prettierrc"
+  }
+}
 ```
 
 You should update it to:
 
 ```json
-"additional_cli_args": ["--config-path", "path/to/prettier/.prettierrc"]
+{
+  "additional_cli_args": {
+    "--config-path": "path/to/prettier/.prettierrc"
+  }
+}
 ```

--- a/messages/1.91.0.txt
+++ b/messages/1.91.0.txt
@@ -1,0 +1,29 @@
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                     _     ____           _   _   _                           │
+│                    | |___|  _ \ _ __ ___| |_| |_(_) ___ _ __                 │
+│                 _  | / __| |_) | '__/ _ \ __| __| |/ _ \ '__|                │
+│                | |_| \__ \  __/| | |  __/ |_| |_| |  __/ |                   │
+│                 \___/|___/_|   |_|  \___|\__|\__|_|\___|_|                   │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+
+## 1.91.0
+
+Release date: 2026-03-19
+
+This release updates the plugin to match Prettier's CLI rename of `--config` to `--config-path`.
+
+You will need to update your plugin setting for `additional_cli_args` (JsPrettier.sublime-settings)
+if you were previously specifying `--config` to point to a custom Prettier configuration file.
+
+For example, if you had:
+
+```json
+"additional_cli_args": ["--config", "path/to/prettier/.prettierrc"]
+```
+
+You should update it to:
+
+```json
+"additional_cli_args": ["--config-path", "path/to/prettier/.prettierrc"]
+```

--- a/messages/1.91.0.txt
+++ b/messages/1.91.0.txt
@@ -11,27 +11,12 @@
 
 Release date: 2026-03-19
 
-This release updates the plugin to match Prettier's CLI rename of `--config` to `--config-path`.
+This release adds support for Prettier's `--config-path` CLI option, introduced
+in Prettier's experimental CLI (`--experimental-cli`).
 
-You will need to update your plugin setting for `additional_cli_args` (JsPrettier.sublime-settings)
-if you were previously specifying `--config` to point to a custom Prettier configuration file.
+When `--experimental-cli` is present in `additional_cli_args`, the plugin
+automatically uses `--config-path` to pass the resolved config file path to
+Prettier. Otherwise, the classic `--config` flag is used.
 
-For example, if you had:
-
-```json
-{
-  "additional_cli_args": {
-    "--config": "path/to/prettier/.prettierrc"
-  }
-}
-```
-
-You should update it to:
-
-```json
-{
-  "additional_cli_args": {
-    "--config-path": "path/to/prettier/.prettierrc"
-  }
-}
-```
+No changes to your settings are required. Both `--config` and `--config-path`
+are accepted as keys in the `additional_cli_args` setting.


### PR DESCRIPTION
This release adds support for Prettier's `--config-path` CLI option, introduced in Prettier's
experimental CLI (`--experimental-cli`).

When `--experimental-cli` is present in `additional_cli_args`, the plugin automatically uses
`--config-path` to pass the resolved config file path to Prettier. Otherwise, the classic `--config`
flag is used. **No changes to your settings are required.**

Both `--config` and `--config-path` are accepted as keys in the `additional_cli_args` setting.